### PR TITLE
Fix missing name argument in UserProxyAgent

### DIFF
--- a/agent_notebook.ipynb
+++ b/agent_notebook.ipynb
@@ -263,7 +263,7 @@
     "\n",
     "agents = [planner, worker, coder, reviewer]\n",
     "group = GroupChat(agents=agents, max_round=30)\n",
-    "proxy = UserProxyAgent(groupchat=group, human_input_mode='NEVER')\n"
+    "proxy = UserProxyAgent(name='user', groupchat=group, human_input_mode='NEVER')\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- fix initialization error in *agent_notebook.ipynb* by specifying a name for `UserProxyAgent`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b2e6e50dc832db66459033fbe714d