### PR TITLE
Fix model discovery by making Ollama URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Agents
 A self-hosted agentic pipeline using ollama, jupyter, and autogen.
+
+## Configuration
+
+The agents expect an Ollama server to be running and reachable. Set the
+environment variable `OLLAMA_BASE_URL` to the full base URL of your Ollama
+instance (for example `http://localhost:11434/v1`). If this variable is not
+provided, the notebook defaults to `http://docker-ai:11434/v1`.

--- a/agent_notebook.ipynb
+++ b/agent_notebook.ipynb
@@ -135,12 +135,12 @@
         "            self.api_key = api_key\n",
         "        def chat(self, messages, temperature=0):\n",
         "            raise NotImplementedError('OpenAIChatCompletionClient is unavailable')\n",
-        "import pathlib, datetime, uuid, subprocess, shlex, markdownify, sys, io, contextlib\n",
+        "import os, pathlib, datetime, uuid, subprocess, shlex, markdownify, sys, io, contextlib\n",
         "\n",
         "REPO_ROOT = pathlib.Path.cwd()\n",
         "LOG_DIR = REPO_ROOT / 'agent_logs'\n",
         "LOG_DIR.mkdir(exist_ok=True, parents=True)\n",
-        "BASE_URL = 'http://docker-ai:11434/v1'\n"
+        "BASE_URL = os.environ.get('OLLAMA_BASE_URL', 'http://docker-ai:11434/v1')\n"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- document how to set `OLLAMA_BASE_URL`
- read the Ollama endpoint from `OLLAMA_BASE_URL` in the notebook

## Testing
- `python -m json.tool agent_notebook.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_686b426ee908832d8d5d5c3df90f139d